### PR TITLE
Row Transposition function added

### DIFF
--- a/Encryption/toolsForSDES.py
+++ b/Encryption/toolsForSDES.py
@@ -69,3 +69,13 @@ def generateFK(permutedPT, key):
 
 def switch(frOutput):
     return frOutput[len(frOutput)//2:] + frOutput[:len(frOutput)//2]
+
+def rowTransposition(plaintext, key):
+  cols = len(key)
+  alphabet = "abcdefghijklmnopqrstuvwxyz"
+  matrix = [list(plaintext[i:i+cols]) for i in range(0, len(plaintext), cols)]
+  if len(matrix[-1]) != cols:
+    matrix[-1] += list(alphabet[-cols+len(matrix[-1]):])
+  return "".join(map(lambda x : "".join(x[1:]), sorted(zip(key, *matrix))))
+    
+    


### PR DESCRIPTION
Row transposition function, takes a plaintext and a key given and returns the cypher text of the transposition.
```python3
k = "4312567"
message = "attackpostponeduntiltwoam"
print(rowTransposition(message, k))
```

The result is this (is a string):

`ttnaaptmtsuoaodwcoixknlypetz`